### PR TITLE
Fix scroll position cookie path

### DIFF
--- a/source/js/src/scroll-cookie.js
+++ b/source/js/src/scroll-cookie.js
@@ -8,7 +8,11 @@ $(document).ready(function() {
   $(window).on("scroll", function() {
     clearTimeout(timeout);
     timeout = setTimeout(function () {
-      Cookies.set("scroll-cookie", ($(window).scrollTop() + "|" + rpath), { expires: 365, path: '' });
+      Cookies.set(
+        "scroll-cookie",
+        ($(window).scrollTop() + "|" + rpath),
+        { expires: 365, path: window.location.pathname }
+      );
     }, 250);
   });
 


### PR DESCRIPTION
## Summary
- fix scroll-cookie path to ensure the scroll position is stored per page

## Testing
- `npm test` *(fails: gulp not found)*