### PR TITLE
Fix tests path and typo

### DIFF
--- a/scripts/tags/note.js
+++ b/scripts/tags/note.js
@@ -1,7 +1,7 @@
 /**
  * note.js | global hexo script.
  *
- * ATTENTION! No need to write this tag in 1 line if u don't want see probally bugs.
+ * ATTENTION! No need to write this tag in 1 line if u don't want see probably bugs.
  *
  * Usage:
  *

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,7 +1,7 @@
 define([
   'intern!object',
   'intern/chai!assert',
-  'intern/order!source/js/helpers.js'
+  'intern/order!source/js/src/utils.js'
 ], function (registerSuite, assert) {
   registerSuite({
     name: 'helpers',

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,7 +1,7 @@
 define([
   'intern!object',
   'intern/chai!assert',
-  'intern/order!source/js/src/utils.js'
+  'intern/order!source/js/src/utils.js' // load test utilities
 ], function (registerSuite, assert) {
   registerSuite({
     name: 'helpers',


### PR DESCRIPTION
## Summary
- fix note.js typo `probally` -> `probably`
- update helpers test to load correct utils module

## Testing
- `npm test` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b982b1fcc832b98aef039664d6fa0